### PR TITLE
Fix float comparison for volume

### DIFF
--- a/commands/volume.go
+++ b/commands/volume.go
@@ -50,12 +50,12 @@ func (c *VolumeCommand) Execute(user *gumble.User, args ...string) (string, bool
 		return fmt.Sprintf(viper.GetString("commands.volume.messages.current_volume"), DJ.Volume), true, nil
 	}
 
-	newVolume, err := strconv.ParseFloat(args[0], 32)
+	newVolume, err := strconv.ParseFloat(args[0], 64)
 	if err != nil {
 		return "", true, errors.New(viper.GetString("commands.volume.messages.parsing_error"))
 	}
 
-	if newVolume <= viper.GetFloat64("volume.lowest") || newVolume >= viper.GetFloat64("volume.highest") {
+	if newVolume < viper.GetFloat64("volume.lowest") || newVolume > viper.GetFloat64("volume.highest") {
 		return "", true, fmt.Errorf(viper.GetString("commands.volume.messages.out_of_range_error"),
 			viper.GetFloat64("volume.lowest"), viper.GetFloat64("volume.highest"))
 	}


### PR DESCRIPTION
#### What type of pull request is this?
- [X] Bug fix
- [ ] New feature
- [ ] Other
---
#### Description of your pull request:
When attempting to set volume to highest or lowest IE 0.01 or 0.8 you receive the error
Error: Volumes must be between the values 0.01 and 0.80.
This pull changes the call to ParseFloat to use 64 bits to keep the same value type and changes the if statement to include the limit values.
